### PR TITLE
Wait for 4DKeyBinds.dll

### DIFF
--- a/4DKeyBinds.h
+++ b/4DKeyBinds.h
@@ -141,8 +141,9 @@ namespace KeyBinds
     using BindCallback = std::add_pointer<void(GLFWwindow* window, int action, int mods)>::type;
 
     inline bool IsLoaded() {
-        
-        // why do I have to do this Tr1Ngle?? Why?????
+
+        // wait for at most 2s for 4DKeyBinds.dll to load, in case we are loaded before it.
+        // This is a one-time wait, due to the static
         static int i = 0;
         while (GetModuleHandleA("4DKeyBinds.dll") == nullptr) {
             if (i++>200)

--- a/4DKeyBinds.h
+++ b/4DKeyBinds.h
@@ -140,8 +140,16 @@ namespace KeyBinds
 {
     using BindCallback = std::add_pointer<void(GLFWwindow* window, int action, int mods)>::type;
 
-    inline bool IsLoaded()
-    {
+    inline bool IsLoaded() {
+        
+        // why do I have to do this Tr1Ngle?? Why?????
+        static int i = 0;
+        while (GetModuleHandleA("4DKeyBinds.dll") == nullptr) {
+            if (i++>200)
+                break;
+            Sleep(10);
+        }
+        
         return GetModuleHandleA("4DKeyBinds.dll") != nullptr;
     }
 


### PR DESCRIPTION
Wait for 4DKeyBinds.dll to get loaded before calling its functions. Timeout for good after 2s.

If someone doesn't like this they can remove it, but it's good to have defaults that work reliably. Without this, mods that are sorted alphabetically before 4DKeyBinds.dll will not be able to add binds.